### PR TITLE
Remove log4j transitive dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.github.knaufk</groupId>
   <artifactId>flink-faker</artifactId>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
   <packaging>jar</packaging>
 
   <name>flink-faker</name>
@@ -18,6 +18,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <spotless-maven-plugin.version>1.20.0</spotless-maven-plugin.version>
+    <log4j.version>2.12.1</log4j.version>
   </properties>
 
   <dependencies>
@@ -62,20 +63,33 @@
     <version>3.17.2</version>
     <scope>test</scope>
    </dependency>
-    <!-- Add logging framework, to produce console output when running in the IDE. -->
-    <!-- These dependencies are excluded from the application JAR by default. -->
+
+    <!-- As lib, just depending on slf4j-api to avoid logger conflict by users -->
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.7</version>
-      <scope>runtime</scope>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.30</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-      <scope>runtime</scope>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -1,9 +1,6 @@
 rootLogger.level = INFO
 rootLogger.appenderRef.console.ref = ConsoleAppender
 
-#logger.sink.name = org.apache.flink.walkthrough.common.sink.AlertSink
-#logger.sink.level = INFO
-
 appender.console.name = ConsoleAppender
 appender.console.type = CONSOLE
 appender.console.layout.type = PatternLayout

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -1,0 +1,10 @@
+rootLogger.level = INFO
+rootLogger.appenderRef.console.ref = ConsoleAppender
+
+#logger.sink.name = org.apache.flink.walkthrough.common.sink.AlertSink
+#logger.sink.level = INFO
+
+appender.console.name = ConsoleAppender
+appender.console.type = CONSOLE
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n


### PR DESCRIPTION
Hi,

Really nice project, thanks for making it available :) 

#  2 small changes suggested in the PR
* I believe it would be beneficial to remove the `runtime` dependency on log4j 1 and limit it to `test` instead, in order to keep this specific logger invisible to clients of this lib and allow them to plug whatever they want on slf4j.
* I also suggest to migrate to log4j2 since version 1 is now deprecated.

# example of issues solved by this PR

When using flink-faker together with Flink 1.12.1, the logs became silent on my project for the following reason:

```
SLF4J: Found binding in [jar:file:/home/svend/.m2/repository/org/slf4j/slf4j-log4j12/1.7.7/slf4j-log4j12-1.7.7.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/svend/.m2/repository/org/apache/logging/log4j/log4j-slf4j-impl/2.12.1/log4j-slf4j-impl-2.12.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
log4j:WARN No appenders could be found for logger (live.aaqua.poc.App2ComputeStats).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
```

As a quick work-around, I was able to simply exclude the log4j 1 lib from the transitive dependencies in my project, but that is not ideal, IMHO. 

```
		<dependency>
			<groupId>com.github.knaufk</groupId>
			<artifactId>flink-faker</artifactId>
			<version>0.1.1</version>
			<exclusions>
				<exclusion>
					<groupId>org.slf4j</groupId>
					<artifactId>slf4j-log4j12</artifactId>
				</exclusion>
				<exclusion>
					<groupId>log4j</groupId>
					<artifactId>log4j</artifactId>
				</exclusion>
			</exclusions>
		</dependency>
```		
