### PR TITLE
Get the tests to compile and pass on Flink 1.13.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <flink.version>1.12.1</flink.version>
+    <flink.version>1.13.0</flink.version>
     <java.version>1.8</java.version>
     <scala.binary.version>2.12</scala.binary.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -169,6 +169,7 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.2</version>
       </plugin>

--- a/src/test/java/com/github/knaufk/flink/faker/FlinkFakerTableSourceFactoryTest.java
+++ b/src/test/java/com/github/knaufk/flink/faker/FlinkFakerTableSourceFactoryTest.java
@@ -201,10 +201,11 @@ class FlinkFakerTableSourceFactoryTest {
       DescriptorProperties descriptorProperties, final TableSchema invalidSchema) {
 
     EnvironmentSettings settings =
-    EnvironmentSettings.newInstance().inStreamingMode().useBlinkPlanner().build();
+        EnvironmentSettings.newInstance().inStreamingMode().useBlinkPlanner().build();
     TableEnvironment tableEnv = TableEnvironment.create(settings);
     TableEnvironmentInternal tableEnvInternal = (TableEnvironmentInternal) tableEnv;
-    CatalogTable catalogTable = new CatalogTableImpl(invalidSchema, descriptorProperties.asMap(), "");
+    CatalogTable catalogTable =
+        new CatalogTableImpl(invalidSchema, descriptorProperties.asMap(), "");
 
     return FactoryUtil.createTableSource(
         null,

--- a/src/test/java/com/github/knaufk/flink/faker/FlinkFakerTableSourceFactoryTest.java
+++ b/src/test/java/com/github/knaufk/flink/faker/FlinkFakerTableSourceFactoryTest.java
@@ -4,8 +4,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.TableEnvironmentInternal;
+import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -195,10 +199,17 @@ class FlinkFakerTableSourceFactoryTest {
 
   private DynamicTableSource createTableSource(
       DescriptorProperties descriptorProperties, final TableSchema invalidSchema) {
+
+    EnvironmentSettings settings =
+    EnvironmentSettings.newInstance().inStreamingMode().useBlinkPlanner().build();
+    TableEnvironment tableEnv = TableEnvironment.create(settings);
+    TableEnvironmentInternal tableEnvInternal = (TableEnvironmentInternal) tableEnv;
+    CatalogTable catalogTable = new CatalogTableImpl(invalidSchema, descriptorProperties.asMap(), "");
+
     return FactoryUtil.createTableSource(
         null,
         ObjectIdentifier.of("", "", ""),
-        new CatalogTableImpl(invalidSchema, descriptorProperties.asMap(), ""),
+        tableEnvInternal.getCatalogManager().resolveCatalogTable(catalogTable),
         new Configuration(),
         Thread.currentThread().getContextClassLoader(),
         false);


### PR DESCRIPTION
Out of the box on Flink 1.13 the tests don't compile. This was enough to get everything working again.

I modeled this on how this was done in HiveDynamicTableFactoryTest, but I don't really know what I'm doing. :)
