### PR TITLE
Faker will not generate null values for columns with zero null rate now

### DIFF
--- a/src/main/java/com/github/knaufk/flink/faker/FlinkFakerSourceFunction.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FlinkFakerSourceFunction.java
@@ -100,7 +100,7 @@ public class FlinkFakerSourceFunction extends RichParallelSourceFunction<RowData
       LogicalTypeRoot typeRoot = (types[i]).getTypeRoot();
 
       float fieldNullRate = fieldNullRates[i];
-      if (rand.nextFloat() > fieldNullRate) {
+      if (rand.nextFloat() >= fieldNullRate) {
         String value = faker.expression(fieldExpressions[i]);
         row.setField(i, FakerUtils.stringValueToType(value, typeRoot));
       } else {


### PR DESCRIPTION
Currently faker might generate, with a small probability, null values for columns with zero null rate. See issue #12 for details.

This PR fixes this issue.

As this change is hard to add a unit test I'm not adding tests in this PR. I've instead tested it on my private cluster.