### PR TITLE
Support for ROW, ARRAY, MAP types

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,27 +50,6 @@ CREATE TEMPORARY TABLE heros (
 
 SELECT * FROM heros;
 ```
-```sql
-CREATE TEMPORARY TABLE hp
-  `character-with-age` MAP<STRING,INT>,
-  `spells` MULTISET<STRING>,
-  `locations` ARRAY<STRING>,
-  `house-points` ROW<`house` STRING, `points` INT>
-) WITH (
-  'connector' = 'faker',
-  'fields.character-with-age.key.expression' = '#{harry_potter.character}',
-  'fields.character-with-age.value.expression' = '#{number.numberBetween ''10'',''100''}',
-  'fields.character-with-age.length' = '2',
-  'fields.spells.expression' = '#{harry_potter.spell}',
-  'fields.spells.length' = '5',
-  'fields.locations.expression' = '#{harry_potter.location}',
-  'fields.locations.length' = '3',
-  'fields.house-points.house.expression' = '#{harry_potter.house}',
-  'fields.house-points.points.expression' = '#{number.numberBetween ''10'',''100''}'
-);
-
-SELECT * FROM hp;
-```
 
 
 ### As LookupTableSource
@@ -140,7 +119,7 @@ Connector Option | Default | Description
 For rows of type `TIMESTAMP`, the corresponding Java Faker expression needs to return a timestamp formatted as `EEE MMM dd HH:mm:ss zzz yyyy`.
 Typically, you would use one of the following expressions:
 
-```
+```sql
 CREATE TEMPORARY TABLE timestamp_example (
   `timestamp1` TIMESTAMP(3),
   `timestamp2` TIMESTAMP(3)
@@ -156,6 +135,32 @@ SELECT * FROM timestamp_example;
 
 For `timestamp1` Java Faker will generate a random timestamp that lies at most 15 seconds in the past.
 For `timestamp2` Java Faker will generate a random timestamp, that lies at most 15 seconds in the past, but at least 5 seconds.
+
+### On Collection Data Types
+
+The usage of `ARRAY`, `MULTISET`, `MAP` and `ROW` types is shown in the following example.
+
+```sql
+CREATE TEMPORARY TABLE hp (
+  `character-with-age` MAP<STRING,INT>,
+  `spells` MULTISET<STRING>,
+  `locations` ARRAY<STRING>,
+  `house-points` ROW<`house` STRING, `points` INT>
+) WITH (
+  'connector' = 'faker',
+  'fields.character-with-age.key.expression' = '#{harry_potter.character}',
+  'fields.character-with-age.value.expression' = '#{number.numberBetween ''10'',''100''}',
+  'fields.character-with-age.length' = '2',
+  'fields.spells.expression' = '#{harry_potter.spell}',
+  'fields.spells.length' = '5',
+  'fields.locations.expression' = '#{harry_potter.location}',
+  'fields.locations.length' = '3',
+  'fields.house-points.house.expression' = '#{harry_potter.house}',
+  'fields.house-points.points.expression' = '#{number.numberBetween ''10'',''100''}'
+);
+
+SELECT * FROM hp;
+```
 
 ### "One Of" Columns
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ CREATE TEMPORARY TABLE heros (
 
 SELECT * FROM heros;
 ```
+```sql
+CREATE TEMPORARY TABLE hp
+  `character-with-age` MAP<STRING,INT>,
+  `spells` MULTISET<STRING>,
+  `locations` ARRAY<STRING>,
+  `house-points` ROW<`house` STRING, `points` INT>
+) WITH (
+  'connector' = 'faker',
+  'fields.character-with-age.key.expression' = '#{harry_potter.character}',
+  'fields.character-with-age.value.expression' = '#{number.numberBetween ''10'',''100''}',
+  'fields.character-with-age.length' = '2',
+  'fields.spells.expression' = '#{harry_potter.spell}',
+  'fields.spells.length' = '5',
+  'fields.locations.expression' = '#{harry_potter.location}',
+  'fields.locations.length' = '3',
+  'fields.house-points.house.expression' = '#{harry_potter.house}',
+  'fields.house-points.points.expression' = '#{number.numberBetween ''10'',''100''}'
+);
+
+SELECT * FROM hp;
+```
+
 
 ### As LookupTableSource
 
@@ -98,6 +120,10 @@ Currently, the `faker` source supports the following data types:
 * `DECIMAL`
 * `BOOLEAN`
 * `TIMESTAMP`
+* `ARRAY`
+* `MAP`
+* `MULTISET`
+* `ROW`
 
 ### Connector Options
 
@@ -107,6 +133,7 @@ Connector Option | Default | Description
 `rows-per-second`| 10000   | The maximum rate at which the source produces records.
 `fields.<field>.expression` | None | The [Java Faker](https://github.com/DiUS/java-faker) expression to generate the values for this field.
 `fields.<field>.null-rate` | 0.0 | Fraction of rows for which this field is `null`
+`fields.<field>.length`| 1 | Size of array, map or multiset
 
 ### On Timestamps
 

--- a/src/main/java/com/github/knaufk/flink/faker/FakerUtils.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FakerUtils.java
@@ -53,20 +53,21 @@ public class FakerUtils {
         //      case INTERVAL_DAY_TIME:
         //        break;
       case ARRAY:
-        Object[] array = new Object[stringArray.length];
+        Object[] arrayElements = new Object[stringArray.length];
         for (int i = 0; i < stringArray.length; i++)
-          array[i] =
+          arrayElements[i] =
               (stringValueToType(
                   new String[] {stringArray[i]}, ((ArrayType) logicalType).getElementType()));
-        return new GenericArrayData(array);
+        return new GenericArrayData(arrayElements);
       case MULTISET:
         Map<Object, Integer> multisetMap = new HashMap<>();
         for (int i = 0; i < stringArray.length; i++) {
-          Object mapKey =
+          Object element =
               stringValueToType(
                   new String[] {stringArray[i]}, ((MultisetType) logicalType).getElementType());
-          Integer mapValue = multisetMap.containsKey(mapKey) ? (multisetMap.get(mapKey) + 1) : 1;
-          multisetMap.put(mapKey, mapValue);
+          Integer multiplicity =
+              multisetMap.containsKey(element) ? (multisetMap.get(element) + 1) : 1;
+          multisetMap.put(element, multiplicity);
         }
         return new GenericMapData(multisetMap);
       case MAP:

--- a/src/main/java/com/github/knaufk/flink/faker/FakerUtils.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FakerUtils.java
@@ -4,11 +4,11 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
 import java.util.Locale;
-import org.apache.flink.table.data.DecimalData;
-import org.apache.flink.table.data.StringData;
-import org.apache.flink.table.data.TimestampData;
-import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import java.util.Map;
+import org.apache.flink.table.data.*;
+import org.apache.flink.table.types.logical.*;
 
 public class FakerUtils {
 
@@ -17,11 +17,12 @@ public class FakerUtils {
   private static DateTimeFormatter formatter =
       DateTimeFormatter.ofPattern(FAKER_DATETIME_FORMAT, new Locale("us"));
 
-  static Object stringValueToType(String value, LogicalTypeRoot logicalType) {
+  static Object stringValueToType(String values, LogicalType logicalType) {
+    String[] stringArray = values.split("\n");
+    String value = stringArray.length > 0 ? stringArray[0] : "";
 
-    switch (logicalType) {
+    switch (logicalType.getTypeRoot()) {
       case CHAR:
-        return StringData.fromString(value);
       case VARCHAR:
         return StringData.fromString(value);
       case BOOLEAN:
@@ -44,9 +45,7 @@ public class FakerUtils {
         //      case DATE:
         //        break;
       case TIME_WITHOUT_TIME_ZONE:
-        return TimestampData.fromInstant(Instant.from(formatter.parse(value)));
       case TIMESTAMP_WITHOUT_TIME_ZONE:
-        return TimestampData.fromInstant(Instant.from(formatter.parse(value)));
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         return TimestampData.fromInstant(Instant.from(formatter.parse(value)));
         //        break;
@@ -54,14 +53,38 @@ public class FakerUtils {
         //        break;
         //      case INTERVAL_DAY_TIME:
         //        break;
-        //      case ARRAY:
-        //        break;
-        //      case MULTISET:
-        //        break;
-        //      case MAP:
-        //        break;
-        //      case ROW:
-        //        break;
+      case ARRAY:
+        Object[] array = new Object[stringArray.length];
+        for (int i = 0; i < stringArray.length; i++)
+          array[i] =
+              (stringValueToType(stringArray[i], ((ArrayType) logicalType).getElementType()));
+        return new GenericArrayData(array);
+      case MULTISET:
+        Map<Object, Integer> multisetMap = new HashMap<>();
+        for (int i = 0; i < stringArray.length; i++) {
+          Object mapKey =
+              stringValueToType(stringArray[i], ((MultisetType) logicalType).getElementType());
+          Integer mapValue = multisetMap.containsKey(mapKey) ? (multisetMap.get(mapKey) + 1) : 1;
+          multisetMap.put(mapKey, mapValue);
+        }
+        return new GenericMapData(multisetMap);
+      case MAP:
+        Map<Object, Object> map = new HashMap<>();
+        for (int i = 0; i < stringArray.length; i++) {
+          String[] data = stringArray[i].split("\t");
+          Object key = stringValueToType(data[0], ((MapType) logicalType).getKeyType());
+          Object val = stringValueToType(data[1], ((MapType) logicalType).getValueType());
+          map.put(key, val);
+        }
+        return new GenericMapData(map);
+      case ROW:
+        String[] data = value.split("\t");
+        GenericRowData row = new GenericRowData(data.length);
+        for (int i = 0; i < ((RowType) logicalType).getFieldCount(); i++) {
+          Object obj = stringValueToType(data[i], ((RowType) logicalType).getTypeAt(i));
+          row.setField(i, obj);
+        }
+        return row;
         //      case DISTINCT_TYPE:
         //        break;
         //      case STRUCTURED_TYPE:

--- a/src/main/java/com/github/knaufk/flink/faker/FlinkFakerTableSource.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FlinkFakerTableSource.java
@@ -13,6 +13,7 @@ public class FlinkFakerTableSource implements ScanTableSource, LookupTableSource
 
   private String[] fieldExpressions;
   private Float[] fieldNullRates;
+  private Integer[] fieldCollectionLengths;
   private TableSchema schema;
   private final LogicalType[] types;
   private long rowsPerSecond;
@@ -21,11 +22,13 @@ public class FlinkFakerTableSource implements ScanTableSource, LookupTableSource
   public FlinkFakerTableSource(
       String[] fieldExpressions,
       Float[] fieldNullRates,
+      Integer[] fieldCollectionLengths,
       TableSchema schema,
       long rowsPerSecond,
       long numberOfRows) {
     this.fieldExpressions = fieldExpressions;
     this.fieldNullRates = fieldNullRates;
+    this.fieldCollectionLengths = fieldCollectionLengths;
     this.schema = schema;
     types =
         Arrays.stream(schema.getFieldDataTypes())
@@ -45,14 +48,24 @@ public class FlinkFakerTableSource implements ScanTableSource, LookupTableSource
     boolean isBounded = numberOfRows != UNLIMITED_ROWS;
     return SourceFunctionProvider.of(
         new FlinkFakerSourceFunction(
-            fieldExpressions, fieldNullRates, types, rowsPerSecond, numberOfRows),
+            fieldExpressions,
+            fieldNullRates,
+            fieldCollectionLengths,
+            types,
+            rowsPerSecond,
+            numberOfRows),
         isBounded);
   }
 
   @Override
   public DynamicTableSource copy() {
     return new FlinkFakerTableSource(
-        fieldExpressions, fieldNullRates, schema, rowsPerSecond, numberOfRows);
+        fieldExpressions,
+        fieldNullRates,
+        fieldCollectionLengths,
+        schema,
+        rowsPerSecond,
+        numberOfRows);
   }
 
   @Override
@@ -63,6 +76,7 @@ public class FlinkFakerTableSource implements ScanTableSource, LookupTableSource
   @Override
   public LookupRuntimeProvider getLookupRuntimeProvider(LookupContext context) {
     return TableFunctionProvider.of(
-        new FlinkFakerLookupFunction(fieldExpressions, fieldNullRates, types, context.getKeys()));
+        new FlinkFakerLookupFunction(
+            fieldExpressions, fieldNullRates, fieldCollectionLengths, types, context.getKeys()));
   }
 }

--- a/src/main/java/com/github/knaufk/flink/faker/FlinkFakerTableSource.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FlinkFakerTableSource.java
@@ -11,7 +11,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 
 public class FlinkFakerTableSource implements ScanTableSource, LookupTableSource {
 
-  private String[] fieldExpressions;
+  private String[][] fieldExpressions;
   private Float[] fieldNullRates;
   private Integer[] fieldCollectionLengths;
   private TableSchema schema;
@@ -20,7 +20,7 @@ public class FlinkFakerTableSource implements ScanTableSource, LookupTableSource
   private long numberOfRows;
 
   public FlinkFakerTableSource(
-      String[] fieldExpressions,
+      String[][] fieldExpressions,
       Float[] fieldNullRates,
       Integer[] fieldCollectionLengths,
       TableSchema schema,

--- a/src/test/java/com/github/knaufk/flink/faker/FlinkFakerIntegrationTest.java
+++ b/src/test/java/com/github/knaufk/flink/faker/FlinkFakerIntegrationTest.java
@@ -47,4 +47,48 @@ public class FlinkFakerIntegrationTest {
 
     assertThat(numRows).isEqualTo(NUM_ROWS);
   }
+
+  @Test
+  public void testFlinkFakerWithComplexTypes() {
+    // test
+
+    EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
+    TableEnvironment tEnv = TableEnvironment.create(settings);
+
+    tEnv.executeSql(
+        "CREATE TEMPORARY TABLE hp (\n"
+            + "  `character-with-age` MAP<STRING,INT>, \n"
+            + "  `spells` MULTISET<STRING>, \n"
+            + "  `locations` ARRAY<STRING>, \n"
+            + "  `house-points` ROW<`house` STRING, `points` INT> \n"
+            + ") WITH (\n"
+            + "  'connector' = 'faker', \n"
+            + "  'fields.character-with-age.key.expression' = '#{harry_potter.character}',\n"
+            + "  'fields.character-with-age.value.expression' = '#{number.numberBetween ''10'',''100''}',\n"
+            + "  'fields.character-with-age.length' = '2',\n"
+            + "  'fields.spells.expression' = '#{harry_potter.spell}',\n"
+            + "  'fields.spells.length' = '5',\n"
+            + "  'fields.locations.expression' = '#{harry_potter.location}',\n"
+            + "  'fields.locations.length' = '3',\n"
+            + "  'fields.house-points.house.expression' = '#{harry_potter.house}',\n"
+            + "  'fields.house-points.points.expression' = '#{number.numberBetween ''10'',''100''}',\n"
+            + "  'number-of-rows' = '3'\n"
+            + ")");
+
+    TableResult tableResult = tEnv.executeSql("SELECT * FROM hp");
+
+    CloseableIterator<Row> collect = tableResult.collect();
+
+    int numRows = 0;
+    while (collect.hasNext()) {
+      Row row = collect.next();
+      // no assertions on map sizes, it may differ from given length due to duplicates
+      assertThat(row.getArity()).isEqualTo(4);
+      assertThat(((String[]) row.getField("locations")).length).isEqualTo(3);
+      assertThat(((Row) row.getField("house-points")).getArity()).isEqualTo(2);
+      numRows++;
+    }
+
+    assertThat(numRows).isEqualTo(3);
+  }
 }

--- a/src/test/java/com/github/knaufk/flink/faker/FlinkFakerLookupFunctionTest.java
+++ b/src/test/java/com/github/knaufk/flink/faker/FlinkFakerLookupFunctionTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.*;
 import org.apache.flink.util.Collector;
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +20,11 @@ class FlinkFakerLookupFunctionTest {
 
     FlinkFakerLookupFunction flinkFakerLookupFunction =
         new FlinkFakerLookupFunction(
-            EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES, neverNull(12), ALL_SUPPORTED_DATA_TYPES, keys);
+            EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES,
+            neverNull(16),
+            getArrayOfOnes(16),
+            ALL_SUPPORTED_DATA_TYPES,
+            keys);
 
     flinkFakerLookupFunction.setCollector(collector);
     flinkFakerLookupFunction.open(null);
@@ -47,7 +50,8 @@ class FlinkFakerLookupFunctionTest {
     FlinkFakerLookupFunction flinkFakerLookupFunction =
         new FlinkFakerLookupFunction(
             EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES,
-            alwaysNull(12),
+            alwaysNull(16),
+            getArrayOfOnes(16),
             ALL_SUPPORTED_DATA_TYPES,
             keys);
 

--- a/src/test/java/com/github/knaufk/flink/faker/FlinkFakerSourceFunctionTest.java
+++ b/src/test/java/com/github/knaufk/flink/faker/FlinkFakerSourceFunctionTest.java
@@ -13,7 +13,8 @@ class FlinkFakerSourceFunctionTest {
   @Test
   public void testSimpleExpressions() throws Exception {
 
-    String[] fieldExpressions = new String[] {"#{food.vegetables}", "#{Food.measurement_sizes}"};
+    String[][] fieldExpressions =
+        new String[][] {{"#{food.vegetables}"}, {"#{Food.measurement_sizes}"}};
 
     LogicalType[] types = {new VarCharType(255), new VarCharType(Integer.MAX_VALUE)};
     FlinkFakerSourceFunction flinkFakerSourceFunction =
@@ -28,9 +29,9 @@ class FlinkFakerSourceFunctionTest {
 
   @Test
   public void testREADME() throws Exception {
-    String[] fieldExpressions =
-        new String[] {
-          "#{superhero.name}", "#{superhero.power}", "#{number.numberBetween '0','1000'}"
+    String[][] fieldExpressions =
+        new String[][] {
+          {"#{superhero.name}"}, {"#{superhero.power}"}, {"#{number.numberBetween '0','1000'}"}
         };
 
     LogicalType[] types = {

--- a/src/test/java/com/github/knaufk/flink/faker/FlinkFakerSourceFunctionTest.java
+++ b/src/test/java/com/github/knaufk/flink/faker/FlinkFakerSourceFunctionTest.java
@@ -17,7 +17,8 @@ class FlinkFakerSourceFunctionTest {
 
     LogicalType[] types = {new VarCharType(255), new VarCharType(Integer.MAX_VALUE)};
     FlinkFakerSourceFunction flinkFakerSourceFunction =
-        new FlinkFakerSourceFunction(fieldExpressions, neverNull(2), types, 100, 10);
+        new FlinkFakerSourceFunction(
+            fieldExpressions, neverNull(2), getArrayOfOnes(2), types, 100, 10);
     flinkFakerSourceFunction.open(new Configuration());
 
     assertThat(flinkFakerSourceFunction.generateNextRow().getArity()).isEqualTo(2);
@@ -36,7 +37,8 @@ class FlinkFakerSourceFunctionTest {
       new VarCharType(Integer.MAX_VALUE), new VarCharType(Integer.MAX_VALUE), new IntType()
     };
     FlinkFakerSourceFunction flinkFakerSourceFunction =
-        new FlinkFakerSourceFunction(fieldExpressions, neverNull(3), types, 100, 10);
+        new FlinkFakerSourceFunction(
+            fieldExpressions, neverNull(3), getArrayOfOnes(3), types, 100, 10);
     flinkFakerSourceFunction.open(new Configuration());
 
     RowData rowData = flinkFakerSourceFunction.generateNextRow();
@@ -52,14 +54,15 @@ class FlinkFakerSourceFunctionTest {
     FlinkFakerSourceFunction flinkFakerSourceFunction =
         new FlinkFakerSourceFunction(
             EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES,
-            neverNull(12),
+            neverNull(16),
+            getArrayOfOnes(16),
             ALL_SUPPORTED_DATA_TYPES,
             100,
             10);
     flinkFakerSourceFunction.open(new Configuration());
 
     RowData rowData = flinkFakerSourceFunction.generateNextRow();
-    assertThat(rowData.getArity()).isEqualTo(12);
+    assertThat(rowData.getArity()).isEqualTo(16);
     for (int i = 0; i < EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length; i++) {
       assertThat(rowData.isNullAt(i)).isFalse();
     }
@@ -71,14 +74,15 @@ class FlinkFakerSourceFunctionTest {
     FlinkFakerSourceFunction flinkFakerSourceFunction =
         new FlinkFakerSourceFunction(
             EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES,
-            alwaysNull(12),
+            alwaysNull(16),
+            getArrayOfOnes(16),
             ALL_SUPPORTED_DATA_TYPES,
             100,
             10);
     flinkFakerSourceFunction.open(new Configuration());
 
     RowData rowData = flinkFakerSourceFunction.generateNextRow();
-    assertThat(rowData.getArity()).isEqualTo(12);
+    assertThat(rowData.getArity()).isEqualTo(16);
     for (int i = 0; i < EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length; i++) {
       assertThat(rowData.isNullAt(i)).isTrue();
     }

--- a/src/test/java/com/github/knaufk/flink/faker/FlinkFakerTableSourceFactoryTest.java
+++ b/src/test/java/com/github/knaufk/flink/faker/FlinkFakerTableSourceFactoryTest.java
@@ -32,6 +32,10 @@ class FlinkFakerTableSourceFactoryTest {
           .field("f8", DataTypes.VARCHAR(255))
           .field("f9", DataTypes.STRING())
           .field("f10", DataTypes.BOOLEAN())
+          .field("f11", DataTypes.ARRAY(DataTypes.INT()))
+          .field("f12", DataTypes.MAP(DataTypes.INT(), DataTypes.VARCHAR(255)))
+          .field("f13", DataTypes.ROW(DataTypes.FIELD("age", DataTypes.INT())))
+          .field("f14", DataTypes.MULTISET(DataTypes.CHAR(10)))
           .build();
 
   private static final TableSchema INVALID_SCHEMA =
@@ -173,6 +177,14 @@ class FlinkFakerTableSourceFactoryTest {
     descriptorProperties.putString("fields.f8.expression", "#{Lorem.characters '255'}");
     descriptorProperties.putString("fields.f9.expression", "#{Lorem.sentence}");
     descriptorProperties.putString("fields.f10.expression", "#{regexify '(true|false){1}'}");
+    descriptorProperties.putString(
+        "fields.f11.expression", "#{number.numberBetween '-32768','32767'}");
+    descriptorProperties.putString(
+        "fields.f12.key.expression", "#{number.numberBetween '-32768','32767'}");
+    descriptorProperties.putString("fields.f12.value.expression", "#{Lorem.characters '255'}");
+    descriptorProperties.putString(
+        "fields.f13.age.expression", "#{number.numberBetween '-32768','32767'}");
+    descriptorProperties.putString("fields.f14.expression", "#{Lorem.characters '10'}");
 
     createTableSource(descriptorProperties, VALID_SCHEMA);
   }

--- a/src/test/java/com/github/knaufk/flink/faker/TestUtils.java
+++ b/src/test/java/com/github/knaufk/flink/faker/TestUtils.java
@@ -1,6 +1,5 @@
 package com.github.knaufk.flink.faker;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import org.apache.flink.table.types.logical.*;
 
@@ -22,7 +21,10 @@ public class TestUtils {
         new TimestampType(),
         new ArrayType(new IntType()),
         new MapType(new IntType(), new VarCharType()),
-        new RowType(new ArrayList<RowType.RowField>() {}),
+        new RowType(
+            Arrays.asList(
+                new RowType.RowField("age", new IntType()),
+                new RowType.RowField("name", new CharType(10)))),
         new MultisetType(new CharType(10))
       };
   public static final String[][] EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES =
@@ -41,7 +43,7 @@ public class TestUtils {
         {"#{date.past '15','5','SECONDS'}"},
         {"#{number.numberBetween '-128','127'}"},
         {"#{number.numberBetween '-128','127'}", "#{Lorem.characters '10'}"},
-        {""},
+        {"#{number.numberBetween '-128','127'}", "#{Lorem.characters '10'}"},
         {"#{Lorem.characters '10'}"}
       };
 

--- a/src/test/java/com/github/knaufk/flink/faker/TestUtils.java
+++ b/src/test/java/com/github/knaufk/flink/faker/TestUtils.java
@@ -25,24 +25,24 @@ public class TestUtils {
         new RowType(new ArrayList<RowType.RowField>() {}),
         new MultisetType(new CharType(10))
       };
-  public static final String[] EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES =
-      new String[] {
-        "#{number.numberBetween '-128','127'}",
-        "#{number.numberBetween '-32768','32767'}",
-        "#{number.numberBetween '-2147483648','2147483647'}",
-        "#{number.randomNumber '12','false'}",
-        "#{number.randomDouble '3','-1000','1000'}",
-        "#{number.randomDouble '3','-1000','1000'}",
-        "#{number.randomDouble '3','-1000','1000'}",
-        "#{Lorem.characters '10'}",
-        "#{Lorem.characters '255'}",
-        "#{Lorem.sentence}",
-        "#{regexify '(true|false){1}'}",
-        "#{date.past '15','5','SECONDS'}",
-        "#{number.numberBetween '-128','127'}",
-        "#{number.numberBetween '-128','127'}\t#{Lorem.characters '10'}",
-        "",
-        "#{Lorem.characters '10'}"
+  public static final String[][] EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES =
+      new String[][] {
+        {"#{number.numberBetween '-128','127'}"},
+        {"#{number.numberBetween '-32768','32767'}"},
+        {"#{number.numberBetween '-2147483648','2147483647'}"},
+        {"#{number.randomNumber '12','false'}"},
+        {"#{number.randomDouble '3','-1000','1000'}"},
+        {"#{number.randomDouble '3','-1000','1000'}"},
+        {"#{number.randomDouble '3','-1000','1000'}"},
+        {"#{Lorem.characters '10'}"},
+        {"#{Lorem.characters '255'}"},
+        {"#{Lorem.sentence}"},
+        {"#{regexify '(true|false){1}'}"},
+        {"#{date.past '15','5','SECONDS'}"},
+        {"#{number.numberBetween '-128','127'}"},
+        {"#{number.numberBetween '-128','127'}", "#{Lorem.characters '10'}"},
+        {""},
+        {"#{Lorem.characters '10'}"}
       };
 
   public static Float[] neverNull(int size) {

--- a/src/test/java/com/github/knaufk/flink/faker/TestUtils.java
+++ b/src/test/java/com/github/knaufk/flink/faker/TestUtils.java
@@ -1,5 +1,7 @@
 package com.github.knaufk.flink.faker;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import org.apache.flink.table.types.logical.*;
 
 public class TestUtils {
@@ -17,7 +19,11 @@ public class TestUtils {
         new VarCharType(255),
         new VarCharType(Integer.MAX_VALUE),
         new BooleanType(),
-        new TimestampType()
+        new TimestampType(),
+        new ArrayType(new IntType()),
+        new MapType(new IntType(), new VarCharType()),
+        new RowType(new ArrayList<RowType.RowField>() {}),
+        new MultisetType(new CharType(10))
       };
   public static final String[] EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES =
       new String[] {
@@ -32,7 +38,11 @@ public class TestUtils {
         "#{Lorem.characters '255'}",
         "#{Lorem.sentence}",
         "#{regexify '(true|false){1}'}",
-        "#{date.past '15','5','SECONDS'}"
+        "#{date.past '15','5','SECONDS'}",
+        "#{number.numberBetween '-128','127'}",
+        "#{number.numberBetween '-128','127'}\t#{Lorem.characters '10'}",
+        "",
+        "#{Lorem.characters '10'}"
       };
 
   public static Float[] neverNull(int size) {
@@ -45,9 +55,13 @@ public class TestUtils {
 
   private static Float[] getNullRates(int size, float v) {
     Float[] zeroNullRates = new Float[size];
-    for (int i = 0; i < zeroNullRates.length; i++) {
-      zeroNullRates[i] = v;
-    }
+    Arrays.fill(zeroNullRates, v);
     return zeroNullRates;
+  }
+
+  public static Integer[] getArrayOfOnes(int size) {
+    Integer[] array = new Integer[size];
+    Arrays.fill(array, 1);
+    return array;
   }
 }


### PR DESCRIPTION
`ARRAY`, `MAP` and `ROW` datatypes are now supported. At the moment they work only with simple inner types. See an example in Readme file. I decided to keep the idea of storing and passing only strings, so to store complex types as strings I used `\t `and `\n` characters as delimiters. This solution assumes that the generated content does not contain these characters. If we want the solution to be more general, we should pass objects (array, map, row, etc.) instead of strings - it is possible, but it would make the logic more complex.