### PR TITLE
Upgrade dependencies to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,13 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <flink.version>1.13.0</flink.version>
+    <flink.version>1.14.0</flink.version>
     <java.version>1.8</java.version>
     <scala.binary.version>2.12</scala.binary.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <spotless-maven-plugin.version>1.20.0</spotless-maven-plugin.version>
-    <log4j.version>2.12.1</log4j.version>
+    <spotless-maven-plugin.version>2.17.4</spotless-maven-plugin.version>
+    <log4j.version>2.14.1</log4j.version>
   </properties>
 
   <dependencies>
@@ -35,7 +35,7 @@
   </dependency>
   <dependency>
     <groupId>org.apache.flink</groupId>
-    <artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+    <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
     <version>${flink.version}</version>
     <scope>test</scope>
   </dependency>
@@ -54,13 +54,13 @@
   <dependency>
 	  <groupId>org.junit.jupiter</groupId>
 	  <artifactId>junit-jupiter-api</artifactId>
-	  <version>5.7.0</version>
+	  <version>5.8.1</version>
 	  <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.assertj</groupId>
     <artifactId>assertj-core</artifactId>
-    <version>3.17.2</version>
+    <version>3.21.0</version>
     <scope>test</scope>
    </dependency>
 
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
+      <version>1.7.32</version>
     </dependency>
 
     <dependency>
@@ -97,7 +97,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.8.1</version>
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
@@ -138,7 +138,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
* Bump Spotless to latest version (2.17.4)
* Bump Log4J to latest version (2.14.1)
* Bump JUnit5 to latest version (5.8.1)
* Bump Assertj to latest version (3.21.0)
* Bump Maven-compiler to latest version (3.8.1)
* Bump Maven Shade plugin to latest version (3.2.4)
* Upgrade Flink to latest version (1.14)