### PR TITLE
Update log4j2 to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <spotless-maven-plugin.version>2.17.4</spotless-maven-plugin.version>
-    <log4j.version>2.14.1</log4j.version>
+    <log4j.version>2.15.0</log4j.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
 2.0 <= Apache log4j2 <= 2.14.1 have a RCE zero day.
https://www.lunasec.io/docs/blog/log4j-zero-day/