### PR TITLE
Enable generation for DATE time, enable millis for TIMESTAMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Currently, the `faker` source supports the following data types:
 * `DECIMAL`
 * `BOOLEAN`
 * `TIMESTAMP`
+* `DATE`
 * `ARRAY`
 * `MAP`
 * `MULTISET`
@@ -107,35 +108,44 @@ Currently, the `faker` source supports the following data types:
 
 ### Connector Options
 
-Connector Option | Default | Description
------------------|---------|-------------
-`number-of-rows` | None    | The number of rows to produce. If this is options is set, the source is bounded otherwise it is unbounded and runs indefinitely.
-`rows-per-second`| 10000   | The maximum rate at which the source produces records.
-`fields.<field>.expression` | None | The [Java Faker](https://github.com/DiUS/java-faker) expression to generate the values for this field.
-`fields.<field>.null-rate` | 0.0 | Fraction of rows for which this field is `null`
-`fields.<field>.length`| 1 | Size of array, map or multiset
+| Connector Option            | Default | Description                                                                                                                      |
+|-----------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------|
+| `number-of-rows`            | None    | The number of rows to produce. If this is options is set, the source is bounded otherwise it is unbounded and runs indefinitely. |
+| `rows-per-second`           | 10000   | The maximum rate at which the source produces records.                                                                           |
+| `fields.<field>.expression` | None    | The [Java Faker](https://github.com/DiUS/java-faker) expression to generate the values for this field.                           |
+| `fields.<field>.null-rate`  | 0.0     | Fraction of rows for which this field is `null`                                                                                  |
+| `fields.<field>.length`     | 1       | Size of array, map or multiset                                                                                                   |
 
 ### On Timestamps
 
-For rows of type `TIMESTAMP`, the corresponding Java Faker expression needs to return a timestamp formatted as `EEE MMM dd HH:mm:ss zzz yyyy`.
+For rows of type `TIMESTAMP`, `DATE` the corresponding Java Faker expression needs to return a timestamp formatted as `uuuu-MM-dd hh:mi:ss[.nnnnnnnnn]`.
 Typically, you would use one of the following expressions:
 
 ```sql
-CREATE TEMPORARY TABLE timestamp_example (
+CREATE TEMPORARY TABLE timestamp_and_date_example (
   `timestamp1` TIMESTAMP(3),
-  `timestamp2` TIMESTAMP(3)
+  `timestamp2` TIMESTAMP(3),
+  `timestamp3` TIMESTAMP(3),
+  `date1`      DATE,
+  `date2`      DATE
 )
 WITH (
   'connector' = 'faker', 
   'fields.timestamp1.expression' = '#{date.past ''15'',''SECONDS''}',
-  'fields.timestamp2.expression' = '#{date.past ''15'',''5'',''SECONDS''}'
+  'fields.timestamp2.expression' = '#{date.past ''15'',''5'',''SECONDS''}',
+  'fields.timestamp3.expression' = '#{date.future ''15'',''5'',''SECONDS''}',
+  'fields.date1.expression' = '#{date.birthday}',
+  'fields.date2.expression' = '#{date.birthday ''1'',''100''}'
 );
 
-SELECT * FROM timestamp_example;
+SELECT * FROM timestamp_and_date_example;
 ```
 
 For `timestamp1` Java Faker will generate a random timestamp that lies at most 15 seconds in the past.
 For `timestamp2` Java Faker will generate a random timestamp, that lies at most 15 seconds in the past, but at least 5 seconds.
+For `timestamp3` Java Faker will generate a random timestamp, that lies at most 15 seconds in the future, but at least 5 seconds.
+For `date1` Java Faker will generate a random birthday between 18 and 65 years ago.
+For `date2` Java Faker will generate a random birthday between 1 and 100 years ago.
 
 ### On Collection Data Types
 

--- a/src/main/java/com/github/knaufk/flink/faker/DateTime.java
+++ b/src/main/java/com/github/knaufk/flink/faker/DateTime.java
@@ -1,0 +1,57 @@
+package com.github.knaufk.flink.faker;
+
+import com.github.javafaker.DateAndTime;
+import com.github.javafaker.Faker;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+public class DateTime extends DateAndTime {
+
+  protected DateTime(Faker faker) {
+    super(faker);
+  }
+
+  public Timestamp past(int atMost, TimeUnit unit) {
+    return new Timestamp(super.past(atMost, unit).getTime());
+  }
+
+  public Timestamp past(int atMost, int minimum, TimeUnit unit) {
+    return new Timestamp(super.past(atMost, minimum, unit).getTime());
+  }
+
+  @Override
+  public Timestamp future(int atMost, TimeUnit unit) {
+    return new Timestamp(super.future(atMost, unit).getTime());
+  }
+
+  @Override
+  public Timestamp future(int atMost, int minimum, TimeUnit unit) {
+    return new Timestamp(super.future(atMost, minimum, unit).getTime());
+  }
+
+  @Override
+  public Timestamp future(int atMost, TimeUnit unit, Date referenceDate) {
+    return new Timestamp(super.future(atMost, unit, referenceDate).getTime());
+  }
+
+  @Override
+  public Timestamp past(int atMost, TimeUnit unit, Date referenceDate) {
+    return new Timestamp(super.past(atMost, unit, referenceDate).getTime());
+  }
+
+  @Override
+  public Timestamp between(Date from, Date to) throws IllegalArgumentException {
+    return new Timestamp(super.between(from, to).getTime());
+  }
+
+  @Override
+  public Timestamp birthday() {
+    return new Timestamp(super.birthday().getTime());
+  }
+
+  @Override
+  public Timestamp birthday(int minAge, int maxAge) {
+    return new Timestamp(super.birthday(minAge, maxAge).getTime());
+  }
+}

--- a/src/main/java/com/github/knaufk/flink/faker/FakerUtils.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FakerUtils.java
@@ -2,20 +2,35 @@ package com.github.knaufk.flink.faker;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.sql.Date;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import org.apache.flink.table.data.*;
-import org.apache.flink.table.types.logical.*;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
 
 public class FakerUtils {
 
-  public static final String FAKER_DATETIME_FORMAT = "EEE MMM dd HH:mm:ss zzz yyyy";
-
-  private static DateTimeFormatter formatter =
-      DateTimeFormatter.ofPattern(FAKER_DATETIME_FORMAT, new Locale("us"));
+  private static final DateTimeFormatter FORMATTER =
+      new DateTimeFormatterBuilder()
+          // Pattern was taken from java.sql.Timestamp#toString
+          .appendPattern("uuuu-MM-dd HH:mm:ss")
+          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+          .toFormatter(Locale.US);
 
   static Object stringValueToType(String[] stringArray, LogicalType logicalType) {
     String value = stringArray.length > 0 ? stringArray[0] : "";
@@ -41,12 +56,16 @@ public class FakerUtils {
         return Float.parseFloat(value);
       case DOUBLE:
         return Double.parseDouble(value);
-        //      case DATE:
-        //        break;
+      case DATE:
+        return (int)
+            (Date.from(Instant.from(FORMATTER.withZone(ZoneId.systemDefault()).parse(value)))
+                    .getTime()
+                / (86400 * 1000));
       case TIME_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITHOUT_TIME_ZONE:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-        return TimestampData.fromInstant(Instant.from(formatter.parse(value)));
+        return TimestampData.fromInstant(
+            Instant.from(FORMATTER.withZone(ZoneId.systemDefault()).parse(value)));
         //        break;
         //              case INTERVAL_YEAR_MONTH:
         //        break;

--- a/src/main/java/com/github/knaufk/flink/faker/FlinkFaker.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FlinkFaker.java
@@ -1,0 +1,45 @@
+package com.github.knaufk.flink.faker;
+
+import com.github.javafaker.Faker;
+import com.github.javafaker.service.FakeValuesService;
+import com.github.javafaker.service.RandomService;
+import java.util.Locale;
+import java.util.Random;
+
+public class FlinkFaker extends Faker {
+  private DateTime dateTime;
+
+  public FlinkFaker() {
+    super();
+    dateTime = new DateTime(this);
+  }
+
+  public FlinkFaker(Locale locale) {
+    super(locale);
+    dateTime = new DateTime(this);
+  }
+
+  public FlinkFaker(Random random) {
+    super(random);
+    dateTime = new DateTime(this);
+  }
+
+  public FlinkFaker(Locale locale, Random random) {
+    super(locale, random);
+    dateTime = new DateTime(this);
+  }
+
+  public FlinkFaker(Locale locale, RandomService randomService) {
+    super(locale, randomService);
+    dateTime = new DateTime(this);
+  }
+
+  public FlinkFaker(FakeValuesService fakeValuesService, RandomService random) {
+    super(fakeValuesService, random);
+    dateTime = new DateTime(this);
+  }
+
+  public DateTime date() {
+    return dateTime;
+  }
+}

--- a/src/main/java/com/github/knaufk/flink/faker/FlinkFakerLookupFunction.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FlinkFakerLookupFunction.java
@@ -1,6 +1,5 @@
 package com.github.knaufk.flink.faker;
 
-import com.github.javafaker.Faker;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -18,7 +17,7 @@ public class FlinkFakerLookupFunction extends TableFunction<RowData> {
   private LogicalType[] types;
   private int[][] keys;
   private List<Integer> keyIndeces;
-  private Faker faker;
+  private FlinkFaker faker;
   private Random rand;
 
   public FlinkFakerLookupFunction(
@@ -44,7 +43,7 @@ public class FlinkFakerLookupFunction extends TableFunction<RowData> {
   @Override
   public void open(FunctionContext context) throws Exception {
     super.open(context);
-    faker = new Faker();
+    faker = new FlinkFaker();
     rand = new Random();
   }
 

--- a/src/main/java/com/github/knaufk/flink/faker/FlinkFakerSourceFunction.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FlinkFakerSourceFunction.java
@@ -44,7 +44,7 @@ public class FlinkFakerSourceFunction extends RichParallelSourceFunction<RowData
   @Override
   public void open(final Configuration parameters) throws Exception {
     super.open(parameters);
-    faker = new Faker();
+    faker = new FlinkFaker();
     rand = new Random();
   }
 

--- a/src/main/java/com/github/knaufk/flink/faker/FlinkFakerTableSourceFactory.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FlinkFakerTableSourceFactory.java
@@ -58,6 +58,7 @@ public class FlinkFakerTableSourceFactory implements DynamicTableSourceFactory {
           LogicalTypeRoot.MAP,
           LogicalTypeRoot.ROW,
           LogicalTypeRoot.MULTISET,
+          LogicalTypeRoot.DATE,
           LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE,
           LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
           LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE);
@@ -176,7 +177,7 @@ public class FlinkFakerTableSourceFactory implements DynamicTableSourceFactory {
     }
 
     try {
-      Faker faker = new Faker();
+      Faker faker = new FlinkFaker();
       for (String expression : fieldExpression) faker.expression(expression);
     } catch (RuntimeException e) {
       throw new ValidationException("Invalid expression for column \"" + fieldName + "\".", e);

--- a/src/test/java/com/github/knaufk/flink/faker/FlinkFakerLookupFunctionTest.java
+++ b/src/test/java/com/github/knaufk/flink/faker/FlinkFakerLookupFunctionTest.java
@@ -21,8 +21,8 @@ class FlinkFakerLookupFunctionTest {
     FlinkFakerLookupFunction flinkFakerLookupFunction =
         new FlinkFakerLookupFunction(
             EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES,
-            neverNull(16),
-            getArrayOfOnes(16),
+            neverNull(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
+            getArrayOfOnes(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             ALL_SUPPORTED_DATA_TYPES,
             keys);
 
@@ -50,8 +50,8 @@ class FlinkFakerLookupFunctionTest {
     FlinkFakerLookupFunction flinkFakerLookupFunction =
         new FlinkFakerLookupFunction(
             EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES,
-            alwaysNull(16),
-            getArrayOfOnes(16),
+            alwaysNull(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
+            getArrayOfOnes(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             ALL_SUPPORTED_DATA_TYPES,
             keys);
 

--- a/src/test/java/com/github/knaufk/flink/faker/FlinkFakerSourceFunctionTest.java
+++ b/src/test/java/com/github/knaufk/flink/faker/FlinkFakerSourceFunctionTest.java
@@ -55,15 +55,16 @@ class FlinkFakerSourceFunctionTest {
     FlinkFakerSourceFunction flinkFakerSourceFunction =
         new FlinkFakerSourceFunction(
             EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES,
-            neverNull(16),
-            getArrayOfOnes(16),
+            neverNull(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
+            getArrayOfOnes(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             ALL_SUPPORTED_DATA_TYPES,
             100,
             10);
     flinkFakerSourceFunction.open(new Configuration());
 
     RowData rowData = flinkFakerSourceFunction.generateNextRow();
-    assertThat(rowData.getArity()).isEqualTo(16);
+    System.out.println(rowData);
+    assertThat(rowData.getArity()).isEqualTo(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length);
     for (int i = 0; i < EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length; i++) {
       assertThat(rowData.isNullAt(i)).isFalse();
     }
@@ -75,15 +76,15 @@ class FlinkFakerSourceFunctionTest {
     FlinkFakerSourceFunction flinkFakerSourceFunction =
         new FlinkFakerSourceFunction(
             EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES,
-            alwaysNull(16),
-            getArrayOfOnes(16),
+            alwaysNull(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
+            getArrayOfOnes(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             ALL_SUPPORTED_DATA_TYPES,
             100,
             10);
     flinkFakerSourceFunction.open(new Configuration());
 
     RowData rowData = flinkFakerSourceFunction.generateNextRow();
-    assertThat(rowData.getArity()).isEqualTo(16);
+    assertThat(rowData.getArity()).isEqualTo(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length);
     for (int i = 0; i < EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length; i++) {
       assertThat(rowData.isNullAt(i)).isTrue();
     }

--- a/src/test/java/com/github/knaufk/flink/faker/FlinkFakerTableSourceFactoryTest.java
+++ b/src/test/java/com/github/knaufk/flink/faker/FlinkFakerTableSourceFactoryTest.java
@@ -42,7 +42,7 @@ class FlinkFakerTableSourceFactoryTest {
       TableSchema.builder()
           .field("f0", DataTypes.STRING())
           .field("f1", DataTypes.VARCHAR(100))
-          .field("f2", DataTypes.DATE())
+          .field("f2", DataTypes.NULL())
           .build();
 
   private static final TableSchema TINY_SCHEMA =
@@ -77,7 +77,7 @@ class FlinkFakerTableSourceFactoryTest {
                   "fields.f10.expression", "#{regexify '(true|false){1}'}");
               createTableSource(descriptorProperties, INVALID_SCHEMA);
             })
-        .withStackTraceContaining("f2 is DATE.");
+        .withStackTraceContaining("f2 is NULL.");
   }
 
   @Test

--- a/src/test/java/com/github/knaufk/flink/faker/TestUtils.java
+++ b/src/test/java/com/github/knaufk/flink/faker/TestUtils.java
@@ -19,6 +19,7 @@ public class TestUtils {
         new VarCharType(Integer.MAX_VALUE),
         new BooleanType(),
         new TimestampType(),
+        new DateType(),
         new ArrayType(new IntType()),
         new MapType(new IntType(), new VarCharType()),
         new RowType(
@@ -41,6 +42,7 @@ public class TestUtils {
         {"#{Lorem.sentence}"},
         {"#{regexify '(true|false){1}'}"},
         {"#{date.past '15','5','SECONDS'}"},
+        {"#{date.future '2','1','DAYS'}"},
         {"#{number.numberBetween '-128','127'}"},
         {"#{number.numberBetween '-128','127'}", "#{Lorem.characters '10'}"},
         {"#{number.numberBetween '-128','127'}", "#{Lorem.characters '10'}"},


### PR DESCRIPTION
The idea is to override java-faker's `date` method to generate `java.sql.Timestamp` instead of `Date`. It prints millis in `toString`.
All the methods are same: just generation of `Timestamp` objects based on `Date`