### PR TITLE
Misprint fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ mvn clean package
 
 1. [Setup Ververica Platform](https://docs.ververica.com/getting_started/installation.html).
 2. Get the link to the flink-faker JAR from the [Releases](https://github.com/knaufk/flink-faker/releases).
-3. Start Ververica Platorm > SQL > Connectors > Create Connector, provide the external URL from step 2 and finish the setup.
+3. Start Ververica Platform > SQL > Connectors > Create Connector, provide the external URL from step 2 and finish the setup.
    
 ![Howto add flink-faker to Ververica Platform](add-faker-connector.gif)
 


### PR DESCRIPTION
This is a trivial PR fixing a misprint
`Platorm` => `Platform`