### PR TITLE
Remove duplicate maven-compiler plugin from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,15 +128,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.2.4</version>
         <executions>


### PR DESCRIPTION
During running `mvn clean package` or any other `mvn ...` there is a warning in output (below).

The reason is that maven-compiler-plugin is specified 2 times in pom with different versions.
The PR removes the second one
```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.github.knaufk:flink-faker:jar:0.4.1
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-compiler-plugin @ line 129, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```
