### PR TITLE
Make spotless running during validate phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <executions>
           <execution>
             <id>spotless-check</id>
-            <phase>verify</phase>
+            <phase>validate</phase>
             <goals>
               <goal>check</goal>
             </goals>


### PR DESCRIPTION
Currently spotless runs during `verify` phase. That means after compilation and tests.
The PR makes it fail faster in case of style or import violations by running during `validate` phase (before compilation)