### PR TITLE
Remove useless field keys and use faker's embedded random

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <flink.version>1.15.2</flink.version>
+    <datafaker.version>1.6.0</datafaker.version>
     <java.version>1.8</java.version>
     <scala.binary.version>2.12</scala.binary.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -43,7 +44,7 @@
     <dependency>
       <groupId>net.datafaker</groupId>
       <artifactId>datafaker</artifactId>
-      <version>1.4.0</version>
+      <version>${datafaker.version}</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/src/main/java/com/github/knaufk/flink/faker/FlinkFakerGenerator.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FlinkFakerGenerator.java
@@ -2,7 +2,6 @@ package com.github.knaufk.flink.faker;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import net.datafaker.Faker;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
@@ -15,7 +14,6 @@ import org.apache.flink.util.Collector;
 class FlinkFakerGenerator extends RichFlatMapFunction<Long, RowData> {
 
   private Faker faker;
-  private Random rand;
 
   private String[][] fieldExpressions;
   private Float[] fieldNullRates;
@@ -42,7 +40,6 @@ class FlinkFakerGenerator extends RichFlatMapFunction<Long, RowData> {
   public void open(final Configuration parameters) throws Exception {
     super.open(parameters);
     faker = new Faker();
-    rand = new Random();
 
     nextReadTime = System.currentTimeMillis();
     soFarThisSecond = 0;
@@ -74,7 +71,7 @@ class FlinkFakerGenerator extends RichFlatMapFunction<Long, RowData> {
     for (int i = 0; i < fieldExpressions.length; i++) {
 
       float fieldNullRate = fieldNullRates[i];
-      if (rand.nextFloat() >= fieldNullRate) {
+      if (faker.random().nextFloat() >= fieldNullRate) {
         List<String> values = new ArrayList<String>();
         for (int j = 0; j < fieldCollectionLengths[i]; j++) {
           for (int k = 0; k < fieldExpressions[i].length; k++) {

--- a/src/main/java/com/github/knaufk/flink/faker/FlinkFakerLookupFunction.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FlinkFakerLookupFunction.java
@@ -2,7 +2,6 @@ package com.github.knaufk.flink.faker;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import net.datafaker.Faker;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -16,10 +15,8 @@ public class FlinkFakerLookupFunction extends TableFunction<RowData> {
   private Float[] fieldNullRates;
   private Integer[] fieldCollectionLengths;
   private LogicalType[] types;
-  private int[][] keys;
   private List<Integer> keyIndeces;
   private Faker faker;
-  private Random rand;
 
   public FlinkFakerLookupFunction(
       String[][] fieldExpressions,
@@ -37,15 +34,12 @@ public class FlinkFakerLookupFunction extends TableFunction<RowData> {
       // we don't support nested rows for now, so this is actually one-dimensional
       keyIndeces.add(keys[i][0]);
     }
-
-    this.keys = keys;
   }
 
   @Override
   public void open(FunctionContext context) throws Exception {
     super.open(context);
     faker = new Faker();
-    rand = new Random();
   }
 
   public void eval(Object... keys) {
@@ -57,7 +51,7 @@ public class FlinkFakerLookupFunction extends TableFunction<RowData> {
         keyCount++;
       } else {
         float fieldNullRate = fieldNullRates[i];
-        if (rand.nextFloat() > fieldNullRate) {
+        if (faker.random().nextFloat() > fieldNullRate) {
           List<String> values = new ArrayList<>();
           for (int j = 0; j < fieldCollectionLengths[i]; j++) {
             for (int k = 0; k < fieldExpressions[i].length; k++) {

--- a/src/main/java/com/github/knaufk/flink/faker/FlinkFakerTableSourceFactory.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FlinkFakerTableSourceFactory.java
@@ -67,6 +67,8 @@ public class FlinkFakerTableSourceFactory implements DynamicTableSourceFactory {
   public static final List<LogicalTypeRoot> COLLECTION_ROOT_TYPES =
       Arrays.asList(LogicalTypeRoot.ARRAY, LogicalTypeRoot.MAP, LogicalTypeRoot.MULTISET);
 
+  private static final Faker FAKER = new Faker();
+
   @Override
   public FlinkFakerTableSource createDynamicTableSource(final Context context) {
 
@@ -154,7 +156,6 @@ public class FlinkFakerTableSourceFactory implements DynamicTableSourceFactory {
       fieldExpression = new String[] {options.get(keyExpression), options.get(valueExpression)};
 
     } else if (dataType.getLogicalType().getTypeRoot() == LogicalTypeRoot.ROW) {
-      StringBuilder stringBuilder = new StringBuilder();
       List<RowType.RowField> rowFields = ((RowType) dataType.getLogicalType()).getFields();
       fieldExpression = new String[rowFields.size()];
       // expression is given element by element
@@ -182,8 +183,7 @@ public class FlinkFakerTableSourceFactory implements DynamicTableSourceFactory {
     }
 
     try {
-      Faker faker = new Faker();
-      for (String expression : fieldExpression) faker.expression(expression);
+      for (String expression : fieldExpression) FAKER.expression(expression);
     } catch (RuntimeException e) {
       throw new ValidationException("Invalid expression for column \"" + fieldName + "\".", e);
     }


### PR DESCRIPTION
The PR removes keys field from `src/main/java/com/github/knaufk/flink/faker/FlinkFakerLookupFunction.java` which is not used and makes use of embedded in faker random instead of a separate one