### PR TITLE
Add support of locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Currently, the `faker` source supports the following data types:
 | `fields.<field>.expression` | None    | The [Data Faker](https://www.datafaker.net/documentation/expressions/) expression to generate the values for this field.         |
 | `fields.<field>.null-rate`  | 0.0     | Fraction of rows for which this field is `null`                                                                                  |
 | `fields.<field>.length`     | 1       | Size of array, map or multiset                                                                                                   |
+| `fields.<field>.locale`     | English | Locale for the corresponding field                                                                                               |
 
 ### On Timestamps
 
@@ -207,6 +208,26 @@ WITH (
 ```
 ```sql
 SELECT * FROM orders;
+```
+
+### Locales
+
+Datafaker allows to specify different locales, however please double-check whether current expressions are supported for the selected locale.
+```sql
+CREATE TEMPORARY TABLE person (
+  `name` STRING,
+  `lastName` STRING
+)
+WITH (
+  'connector' = 'faker',
+  'fields.name.expression' = '#{Name.firstName}',
+  'fields.name.locale' = 'ja-JP',
+  'fields.lastName.expression' = '#{Name.firstName}',
+  'fields.lastName.locale' = 'de-DE'
+);
+```
+```sql
+SELECT * FROM person;
 ```
 
 ## License

--- a/src/main/java/com/github/knaufk/flink/faker/FlinkFakerGenerator.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FlinkFakerGenerator.java
@@ -2,6 +2,7 @@ package com.github.knaufk.flink.faker;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import net.datafaker.Faker;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
@@ -16,6 +17,7 @@ class FlinkFakerGenerator extends RichFlatMapFunction<Long, RowData> {
   private Faker faker;
 
   private String[][] fieldExpressions;
+  private Locale[][] locales;
   private Float[] fieldNullRates;
   private Integer[] fieldCollectionLengths;
   private LogicalType[] types;
@@ -25,11 +27,13 @@ class FlinkFakerGenerator extends RichFlatMapFunction<Long, RowData> {
 
   public FlinkFakerGenerator(
       String[][] fieldExpressions,
+      Locale[][] locales,
       Float[] fieldNullRates,
       Integer[] fieldCollectionLengths,
       LogicalType[] types,
       long rowsPerSecond) {
     this.fieldExpressions = fieldExpressions;
+    this.locales = locales;
     this.fieldNullRates = fieldNullRates;
     this.fieldCollectionLengths = fieldCollectionLengths;
     this.types = types;
@@ -76,7 +80,11 @@ class FlinkFakerGenerator extends RichFlatMapFunction<Long, RowData> {
         for (int j = 0; j < fieldCollectionLengths[i]; j++) {
           for (int k = 0; k < fieldExpressions[i].length; k++) {
             // loop for multiple expressions of one field (like map, row fields)
-            values.add(faker.expression(fieldExpressions[i][k]));
+            final int finalI = i;
+            final int finalK = k;
+            values.add(
+                faker.doWith(
+                    () -> faker.expression(fieldExpressions[finalI][finalK]), locales[i][k]));
           }
         }
 

--- a/src/main/java/com/github/knaufk/flink/faker/FlinkFakerLookupFunction.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FlinkFakerLookupFunction.java
@@ -13,6 +13,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 public class FlinkFakerLookupFunction extends LookupFunction {
 
   private String[][] fieldExpressions;
+  private Locale[][] locales;
   private Float[] fieldNullRates;
   private Integer[] fieldCollectionLengths;
   private LogicalType[] types;
@@ -21,11 +22,13 @@ public class FlinkFakerLookupFunction extends LookupFunction {
 
   public FlinkFakerLookupFunction(
       String[][] fieldExpressions,
+      Locale[][] locales,
       Float[] fieldNullRates,
       Integer[] fieldCollectionLengths,
       LogicalType[] types,
       int[][] keys) {
     this.fieldExpressions = fieldExpressions;
+    this.locales = locales;
     this.fieldNullRates = fieldNullRates;
     this.fieldCollectionLengths = fieldCollectionLengths;
     this.types = types;
@@ -58,7 +61,11 @@ public class FlinkFakerLookupFunction extends LookupFunction {
           for (int j = 0; j < fieldCollectionLengths[i]; j++) {
             for (int k = 0; k < fieldExpressions[i].length; k++) {
               // loop for multiple expressions of one field (like map, row fields)
-              values.add(faker.expression(fieldExpressions[i][k]));
+              final int finalI = i;
+              final int finalK = k;
+              values.add(
+                  faker.doWith(
+                      () -> faker.expression(fieldExpressions[finalI][finalK]), locales[i][k]));
             }
           }
           row.setField(

--- a/src/main/java/com/github/knaufk/flink/faker/FlinkFakerTableSource.java
+++ b/src/main/java/com/github/knaufk/flink/faker/FlinkFakerTableSource.java
@@ -2,6 +2,7 @@ package com.github.knaufk.flink.faker;
 
 import static com.github.knaufk.flink.faker.FlinkFakerTableSourceFactory.UNLIMITED_ROWS;
 
+import java.util.Locale;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -23,6 +24,7 @@ public class FlinkFakerTableSource
     implements ScanTableSource, LookupTableSource, SupportsLimitPushDown {
 
   private String[][] fieldExpressions;
+  private Locale[][] locales;
   private Float[] fieldNullRates;
   private Integer[] fieldCollectionLengths;
   private ResolvedSchema schema;
@@ -32,12 +34,14 @@ public class FlinkFakerTableSource
 
   public FlinkFakerTableSource(
       String[][] fieldExpressions,
+      Locale[][] locales,
       Float[] fieldNullRates,
       Integer[] fieldCollectionLengths,
       ResolvedSchema schema,
       long rowsPerSecond,
       long numberOfRows) {
     this.fieldExpressions = fieldExpressions;
+    this.locales = locales;
     this.fieldNullRates = fieldNullRates;
     this.fieldCollectionLengths = fieldCollectionLengths;
     this.schema = schema;
@@ -74,7 +78,12 @@ public class FlinkFakerTableSource
 
         return sequence.flatMap(
             new FlinkFakerGenerator(
-                fieldExpressions, fieldNullRates, fieldCollectionLengths, types, rowsPerSecond));
+                fieldExpressions,
+                locales,
+                fieldNullRates,
+                fieldCollectionLengths,
+                types,
+                rowsPerSecond));
       }
 
       @Override
@@ -88,6 +97,7 @@ public class FlinkFakerTableSource
   public DynamicTableSource copy() {
     return new FlinkFakerTableSource(
         fieldExpressions,
+        locales,
         fieldNullRates,
         fieldCollectionLengths,
         schema,
@@ -106,7 +116,12 @@ public class FlinkFakerTableSource
       @Override
       public LookupFunction createLookupFunction() {
         return new FlinkFakerLookupFunction(
-            fieldExpressions, fieldNullRates, fieldCollectionLengths, types, context.getKeys());
+            fieldExpressions,
+            locales,
+            fieldNullRates,
+            fieldCollectionLengths,
+            types,
+            context.getKeys());
       }
     };
   }

--- a/src/test/java/com/github/knaufk/flink/faker/FlinkFakerGeneratorTest.java
+++ b/src/test/java/com/github/knaufk/flink/faker/FlinkFakerGeneratorTest.java
@@ -18,7 +18,8 @@ class FlinkFakerGeneratorTest {
 
     LogicalType[] types = {new VarCharType(255), new VarCharType(Integer.MAX_VALUE)};
     FlinkFakerGenerator flinkFakerSourceFunction =
-        new FlinkFakerGenerator(fieldExpressions, neverNull(2), getArrayOfOnes(2), types, 100);
+        new FlinkFakerGenerator(
+            fieldExpressions, getDefaultLocales(2), neverNull(2), getArrayOfOnes(2), types, 100);
     flinkFakerSourceFunction.open(new Configuration());
 
     assertThat(flinkFakerSourceFunction.generateNextRow().getArity()).isEqualTo(2);
@@ -37,7 +38,8 @@ class FlinkFakerGeneratorTest {
       new VarCharType(Integer.MAX_VALUE), new VarCharType(Integer.MAX_VALUE), new IntType()
     };
     FlinkFakerGenerator flinkFakerSourceFunction =
-        new FlinkFakerGenerator(fieldExpressions, neverNull(3), getArrayOfOnes(3), types, 100);
+        new FlinkFakerGenerator(
+            fieldExpressions, getDefaultLocales(3), neverNull(3), getArrayOfOnes(3), types, 100);
     flinkFakerSourceFunction.open(new Configuration());
 
     RowData rowData = flinkFakerSourceFunction.generateNextRow();
@@ -53,6 +55,7 @@ class FlinkFakerGeneratorTest {
     FlinkFakerGenerator flinkFakerSourceFunction =
         new FlinkFakerGenerator(
             EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES,
+            getDefaultLocales(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             neverNull(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             getArrayOfOnes(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             ALL_SUPPORTED_DATA_TYPES,
@@ -72,6 +75,7 @@ class FlinkFakerGeneratorTest {
     FlinkFakerGenerator flinkFakerSourceFunction =
         new FlinkFakerGenerator(
             EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES,
+            getDefaultLocales(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             alwaysNull(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             getArrayOfOnes(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             ALL_SUPPORTED_DATA_TYPES,

--- a/src/test/java/com/github/knaufk/flink/faker/FlinkFakerLookupFunctionTest.java
+++ b/src/test/java/com/github/knaufk/flink/faker/FlinkFakerLookupFunctionTest.java
@@ -21,6 +21,7 @@ class FlinkFakerLookupFunctionTest {
     FlinkFakerLookupFunction flinkFakerLookupFunction =
         new FlinkFakerLookupFunction(
             EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES,
+            getDefaultLocales(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             neverNull(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             getArrayOfOnes(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             ALL_SUPPORTED_DATA_TYPES,
@@ -50,6 +51,7 @@ class FlinkFakerLookupFunctionTest {
     FlinkFakerLookupFunction flinkFakerLookupFunction =
         new FlinkFakerLookupFunction(
             EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES,
+            getDefaultLocales(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             alwaysNull(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             getArrayOfOnes(EXPRESSIONS_FOR_ALL_SUPPORTED_DATATYPES.length),
             ALL_SUPPORTED_DATA_TYPES,

--- a/src/test/java/com/github/knaufk/flink/faker/TestUtils.java
+++ b/src/test/java/com/github/knaufk/flink/faker/TestUtils.java
@@ -1,7 +1,25 @@
 package com.github.knaufk.flink.faker;
 
 import java.util.Arrays;
-import org.apache.flink.table.types.logical.*;
+import java.util.Locale;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
 
 public class TestUtils {
 
@@ -69,5 +87,11 @@ public class TestUtils {
     Integer[] array = new Integer[size];
     Arrays.fill(array, 1);
     return array;
+  }
+
+  public static Locale[][] getDefaultLocales(int size) {
+    Locale[][] locales = new Locale[size][];
+    Arrays.fill(locales, new Locale[] {Locale.ENGLISH, Locale.ENGLISH});
+    return locales;
   }
 }


### PR DESCRIPTION
The idea is to enable locale selection for fields since datafaker supports execution under different locale via
`'fields.name.locale' = 'ja-JP'`

fallback locale is `Locale.ENGLISH` (default datafaker's locale)

e.g.
```sql

CREATE TEMPORARY TABLE person (
  `name` STRING,
  `lastName` STRING
)
WITH (
  'connector' = 'faker',
  'fields.name.expression' = '#{Name.firstName}',
  'fields.name.locale' = 'ja-JP',
  'fields.lastName.expression' = '#{Name.lastName}',
  'fields.lastName.locale' = 'de-DE'
);
```
